### PR TITLE
🎉 Solutions to 02_datatypes in haskell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@
 /haskell_*/slides/*.vrb
 /haskell_*/slides/auto/
 /haskell_*/slides/_minted-*/
+
+**/.stack-work/**
+**/*.lock
+**/.tool

--- a/haskell_101/codelab/02_datatypes/src/Codelab.hs
+++ b/haskell_101/codelab/02_datatypes/src/Codelab.hs
@@ -68,7 +68,6 @@ minutes (Minutes m) = m
 -- This is using the $ expression, that helps removing the ()
 timeDistance (Minutes m) (Minutes n) = Minutes $ abs (n - m)
 
-
 type Point = (Int, Int)
 
 -- Do not forget about Hoogle (see above), should you need a new function.
@@ -82,4 +81,11 @@ type Point = (Int, Int)
 --     f :: Point -> Int
 --     f (x, y) = abs x + abs y
 pointDistance :: Point -> Point -> Double
-pointDistance p1 p2 = codelab
+
+-- Distance between 2 points is https://www.calculatorsoup.com/calculators/geometry-plane/distance-two-points.php
+-- point distance is sqrt [ (x2 - x1)^2 + (y2 - y1)^2 ]
+-- sqrt = https://hackage.haskell.org/package/numeric-prelude-0.4.3.3/docs/Algebra-Algebraic.html#v:sqrt
+-- power = https://hackage.haskell.org/package/numeric-prelude-0.4.3.3/docs/Number-Complex.html#v:power
+-- Instead of power, we an use the same operator in languages
+-- also, removing the parenthesis with the $ operator
+pointDistance (x1, y1) (x2, y2) = sqrt . fromIntegral $ (x2 - x1)^2 + (y2 - y1)^2

--- a/haskell_101/codelab/02_datatypes/src/Codelab.hs
+++ b/haskell_101/codelab/02_datatypes/src/Codelab.hs
@@ -56,8 +56,14 @@ minutes (Minutes m) = m
 --
 -- Distance here means the number of minutes to get from m1 to m2.  For
 -- example, for 15 and 25, distance is 10.
-timeDistance :: Minutes -> Minutes -> Minutes
-timeDistance m1 m2 = codelab
+--timeDistance :: Minutes -> Minutes -> Minutes
+--timeDistance (Minutes m) (Minutes n) = if n > m
+--  then (Minutes (n - m))
+--  else (Minutes (m - n))
+
+-- Also having the absolute function when the values are inverted
+-- https://hackage.haskell.org/package/base-4.16.0.0/docs/Prelude.html#v:abs
+timeDistance (Minutes m) (Minutes n) = (Minutes ( abs (n - m) ))
 
 type Point = (Int, Int)
 

--- a/haskell_101/codelab/02_datatypes/src/Codelab.hs
+++ b/haskell_101/codelab/02_datatypes/src/Codelab.hs
@@ -63,7 +63,11 @@ minutes (Minutes m) = m
 
 -- Also having the absolute function when the values are inverted
 -- https://hackage.haskell.org/package/base-4.16.0.0/docs/Prelude.html#v:abs
-timeDistance (Minutes m) (Minutes n) = (Minutes ( abs (n - m) ))
+-- timeDistance (Minutes m) (Minutes n) = (Minutes ( abs (n - m) ))
+
+-- This is using the $ expression, that helps removing the ()
+timeDistance (Minutes m) (Minutes n) = Minutes $ abs (n - m)
+
 
 type Point = (Int, Int)
 

--- a/haskell_101/codelab/02_datatypes/src/Codelab.hs
+++ b/haskell_101/codelab/02_datatypes/src/Codelab.hs
@@ -37,7 +37,15 @@ data Minutes = Minutes Int
 --
 --     div a b
 hours :: Minutes -> Int
-hours m = codelab
+hours (Minutes m) = m `div` 60
+
+-- Pattern matching for the seconds is just a multiplier
+seconds :: Minutes -> Int
+seconds (Minutes m) = m * 60
+
+-- Pattern matching for the minutes is an identity function
+minutes :: Minutes -> Int
+minutes (Minutes m) = m
 
 -- In case you need some mathematical functions, you can use
 --

--- a/haskell_101/codelab/02_datatypes/src/Main.hs
+++ b/haskell_101/codelab/02_datatypes/src/Main.hs
@@ -33,6 +33,8 @@ tests :: Tests
 tests =
   [ test "hours (Minutes 271)" 4 $ C.hours (C.Minutes 271)
   , test "hours (Minutes 15)" 0 $ C.hours (C.Minutes 15)
+  , test "minutes (Minutes 43)" 43 $ C.minutes (C.Minutes 43)
+  , test "seconds (Minutes 53)" 3180 $ C.seconds (C.Minutes 53)
   , test "timeDistance (Minutes 15) (Minutes 25)" (C.Minutes 10) $ C.timeDistance (C.Minutes 15) (C.Minutes 25)
   , test "timeDistance (Minutes 99) (Minutes 47)" (C.Minutes 52) $ C.timeDistance (C.Minutes 99) (C.Minutes 47)
   , test "pointDistance (1, 1) (1, 3)" 2 $ C.pointDistance (1, 1) (1, 3)

--- a/haskell_101/codelab/Dockerfile
+++ b/haskell_101/codelab/Dockerfile
@@ -1,11 +1,29 @@
+# syntax = docker/dockerfile:1.2
+
 # Using haskell:8 instead of latest due to deprecation warnings
 # on cabal
+FROM alpine AS dependencies
+
+# https://stackoverflow.com/questions/49939960/docker-copy-files-using-glob-pattern/66137816#66137816
+WORKDIR /google/trainings/haskell/cabal
+RUN --mount=type=bind,target=/docker-context \
+    cd /docker-context/; \
+    #find . -name "package.json" -mindepth 0 -maxdepth 4 -exec cp --parents "{}" /app/ \;
+    # https://unix.stackexchange.com/questions/15308/how-to-use-find-command-to-search-for-multiple-extensions/15309#15309
+    find . -type f \( -iname \*.cabal -o -iname \*.yaml\* \) -mindepth 0 -maxdepth 2 \
+         -exec cp --parents "{}" /google/trainings/haskell/cabal/ \;
+
 FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master
 
 WORKDIR /google/trainings/haskell
 
-# Copy all source files into container
-COPY . .
+# Copy all cabal dependencies files only, fetched from docker-context
+COPY --from=dependencies /google/trainings/haskell/cabal .
+
+# Copy also the Makefile with the dependency task
+COPY Makefile .
 
 RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}
 RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps
+
+COPY . .

--- a/haskell_101/codelab/Dockerfile
+++ b/haskell_101/codelab/Dockerfile
@@ -1,7 +1,0 @@
-# Using haskell:8 instead of latest due to deprecation warnings
-# on cabal
-FROM haskell:8
-WORKDIR .
-
-# Copy all source files into container
-COPY . .

--- a/haskell_101/codelab/Dockerfile
+++ b/haskell_101/codelab/Dockerfile
@@ -1,0 +1,11 @@
+# Using haskell:8 instead of latest due to deprecation warnings
+# on cabal
+FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master
+
+WORKDIR /google/trainings/haskell
+
+# Copy all source files into container
+COPY . .
+
+RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}
+RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps

--- a/haskell_101/codelab/Makefile
+++ b/haskell_101/codelab/Makefile
@@ -24,9 +24,6 @@ BUILD_GENERATED = dist dist-newstyle .stack-work stack.yaml.lock $(TOOL) $(REPL)
 repl: $(REPL)
 	@`cat $(REPL)` :$(TARGET)
 
-###
-### Just cache the dependencies when running the builds
-###
 deps: $(TOOL)
 	@`cat $(TOOL)` build --dependencies-only $(TARGET)
 

--- a/haskell_101/codelab/Makefile
+++ b/haskell_101/codelab/Makefile
@@ -1,0 +1,51 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.DEFAULT_GOAL := run
+.PHONY: repl run clean
+
+TARGET = codelab
+
+TOOL = .tool
+REPL = .repl_tool
+BUILD_GENERATED = dist dist-newstyle .stack-work stack.yaml.lock $(TOOL) $(REPL)
+
+repl: $(REPL)
+	@`cat $(REPL)` :$(TARGET)
+
+###
+### Just cache the dependencies when running the builds
+###
+deps: $(TOOL)
+	@`cat $(TOOL)` build --dependencies-only $(TARGET)
+
+run: $(TOOL)
+	@`cat $(TOOL)` run $(TARGET)
+
+clean:
+	@$(RM) -r $(BUILD_GENERATED)
+
+#
+# Private rules to check which toolchain is available
+#
+
+$(TOOL):
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(TOOL) || (test -e `which cabal` && echo cabal > $(TOOL)) || true)
+	@(test -s $(TOOL) || (cat setup.md && false))
+
+$(REPL):
+	@(test -e `which stack` && echo stack > $(TOOL) || true)
+	@(test -s $(REPL) || (test -e `which cabal` && echo cabal repl > $(REPL)) || true)
+	@(test -s $(REPL) || (cat setup.md && false))

--- a/haskell_101/codelab/README.md
+++ b/haskell_101/codelab/README.md
@@ -63,3 +63,39 @@ make: Leaving directory '/01_functions'
 Running the first time would result in downloading and compiling needed dependencies (omitted from the above screen output).
 
 When done, you can cleanup Docker services with `docker-compose down`.
+
+# Resolving with docker-compose
+
+```console
+$ docker-compose up --build 02_datatypes
+Building 02_datatypes
+[+] Building 0.2s (10/10) FINISHED
+ => [internal] load build definition from Dockerfile                                                                                                                      0
+ => => transferring dockerfile: 37B                                                                                                                                       0
+ => [internal] load .dockerignore                                                                                                                                         0
+ => => transferring context: 2B                                                                                                                                           0
+ => [internal] load metadata for registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                         0
+ => [1/5] FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                                           0
+ => [internal] load build context                                                                                                                                         0
+ => => transferring context: 19.90kB                                                                                                                                      0
+ => CACHED [2/5] WORKDIR /google/trainings/haskell                                                                                                                        0
+ => CACHED [3/5] COPY . .                                                                                                                                                 0
+ => CACHED [4/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                                             0
+ => CACHED [5/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                                          0
+ => exporting to image                                                                                                                                                    0
+ => => exporting layers                                                                                                                                                   0
+ => => writing image sha256:6d799087e01a19d121c45ecc60a0ebdcfe1e0d6155369d01efe135cb4d8544cc                                                                              0
+ => => naming to docker.io/google/haskell-trainings                                                                                                                       0
+Starting codelab_02_datatypes_1 ... done
+Attaching to codelab_02_datatypes_1
+02_datatypes_1     | make: Entering directory '/google/trainings/haskell/02_datatypes'
+02_datatypes_1     | hours (Minutes 271)                       OK got: 4
+02_datatypes_1     | hours (Minutes 15)                        OK got: 0
+02_datatypes_1     | timeDistance (Minutes 15) (Minutes 25)    !! error: SOMETHING IS NOT IMPLEMENTED!
+02_datatypes_1     | timeDistance (Minutes 99) (Minutes 47)    !! error: SOMETHING IS NOT IMPLEMENTED!
+02_datatypes_1     | pointDistance (1, 1) (1, 3)               !! error: SOMETHING IS NOT IMPLEMENTED!
+02_datatypes_1     | pointDistance (3, 4) (0, 0)               !! error: SOMETHING IS NOT IMPLEMENTED!
+02_datatypes_1     | make: *** [Makefile:34: run] Error 1
+02_datatypes_1     | make: Leaving directory '/google/trainings/haskell/02_datatypes'
+codelab_02_datatypes_1 exited with code 2
+```

--- a/haskell_101/codelab/docker-compose.yml
+++ b/haskell_101/codelab/docker-compose.yml
@@ -12,6 +12,11 @@ x-docker-cli-mode: &docker-cli-mode
   entrypoint: /bin/sh -c
   command: bash
 
+####
+#### you can execute the code as follows:
+#### 
+####      docker-compose up --build 0x_yyyyy 
+####
 services:
 
   00_setup:
@@ -25,6 +30,8 @@ services:
 
   02_datatypes:
     <<: [ *generic-haskell-runtime ]
+    # You can run in CLI mode with "docker-compose run 02_datatypes"
+    #<<: [ *docker-cli-mode ]
     command: make -C 02_datatypes
 
   03_lists:

--- a/haskell_101/codelab/docker-compose.yml
+++ b/haskell_101/codelab/docker-compose.yml
@@ -1,35 +1,44 @@
 version: '3'
+
+x-haskell-docker-setup: &generic-haskell-runtime
+  image: google/haskell-trainings
+  build: .
+
+# When setting the CLI mode, run the command docker-compose run SERVICE_NAME
+# https://stackoverflow.com/questions/36249744/interactive-shell-using-docker-compose/36265910#36265910 
+# Run with docker-compose run SERVICE
+# MUST ENABLE IT IN THE SERVICE BELOW
+x-docker-cli-mode: &docker-cli-mode
+  entrypoint: /bin/sh -c
+  command: bash
+
 services:
+
   00_setup:
-    #build: .
-    image: registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master
-    command: bash 
-    #make -C 00_setup
-    working_dir: /supercash/haskell
-    volumes:
-      - .:/supercash/haskell
+    <<: [ *generic-haskell-runtime ]
+    #<<: [ *docker-cli-mode ]
+    command: make -C 00_setup
+
   01_functions:
-    build: .
-    image: haskell101:latest
+    <<: [ *generic-haskell-runtime ]
     command: make -C 01_functions
+
   02_datatypes:
-    build: .
-    image: haskell101:latest
+    <<: [ *generic-haskell-runtime ]
     command: make -C 02_datatypes
+
   03_lists:
-    build: .
-    image: haskell101:latest
+    <<: [ *generic-haskell-runtime ]
     command: make -C 03_lists
+
   04_abstractions:
-    build: .
-    image: haskell101:latest
+    <<: [ *generic-haskell-runtime ]
     command: make -C 04_abstractions
+
   05_maybe:
-    build: .
-    image: haskell101:latest
+    <<: [ *generic-haskell-runtime ]
     command: make -C 05_maybe
+
   06_rps:
-    build: .
-    image: haskell101:latest
+    <<: [ *generic-haskell-runtime ]
     command: make -C 06_rps
-    tty: true

--- a/haskell_101/codelab/docker-compose.yml
+++ b/haskell_101/codelab/docker-compose.yml
@@ -11,6 +11,9 @@ x-haskell-docker-setup: &generic-haskell-runtime
 x-docker-cli-mode: &docker-cli-mode
   entrypoint: /bin/sh -c
   command: bash
+  # Preserve terminal colors when running containers
+  # https://github.com/docker/compose/issues/2231#issuecomment-425135985
+  tty: yes
 
 ####
 #### you can execute the code as follows:


### PR DESCRIPTION
# 💡 Solutions

```console
$ docker-compose up --build 02_datatypes
Building 02_datatypes
[+] Building 2.2s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                         0.0s
 => => transferring dockerfile: 37B                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                            0.0s
 => => transferring context: 2B                                                                                                                              0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                 0.4s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                            0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                             0.0s
 => [internal] load metadata for registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                            0.0s
 => [internal] load build context                                                                                                                            0.0s
 => => transferring context: 21.11kB                                                                                                                         0.0s
 => [stage-1 1/7] FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                      0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                         0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                        0.0s
 => [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* ) -minde  0.3s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell                                                                                                   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                          0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                     0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                        0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                     0.0s
 => [stage-1 7/7] COPY . .                                                                                                                                   0.3s
 => exporting to image                                                                                                                                       0.6s
 => => exporting layers                                                                                                                                      0.6s
 => => writing image sha256:e5ad5c0e73cd820d8bb974453af0da50211583482282947b2f3e7ad616036644                                                                 0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                          0.0s
Recreating codelab_02_datatypes_1 ... done
Attaching to codelab_02_datatypes_1
02_datatypes_1     | make: Entering directory '/google/trainings/haskell/02_datatypes'
02_datatypes_1     | codelab> configure (exe)
02_datatypes_1     | Configuring codelab-0.1.0.0...
02_datatypes_1     | codelab> build (exe)
02_datatypes_1     | Preprocessing executable 'codelab' for codelab-0.1.0.0..
02_datatypes_1     | Building executable 'codelab' for codelab-0.1.0.0..
02_datatypes_1     | [2 of 3] Compiling Codelab
02_datatypes_1     | [3 of 3] Compiling Main
02_datatypes_1     | Linking .stack-work/dist/x86_64-linux/Cabal-3.2.1.0/build/codelab/codelab ...
02_datatypes_1     | codelab> copy/register
02_datatypes_1     | Installing executable codelab in /google/trainings/haskell/02_datatypes/.stack-work/install/x86_64-linux/b75127df98e825dd26b7ce71e8ebbb670312dcae0b6d352496233a58a9f2a774/8.10.7/bin
02_datatypes_1     | Installing executable solution in /google/trainings/haskell/02_datatypes/.stack-work/install/x86_64-linux/b75127df98e825dd26b7ce71e8ebbb670312dcae0b6d352496233a58a9f2a774/8.10.7/bin
02_datatypes_1     | hours (Minutes 271)                       OK got: 4
02_datatypes_1     | hours (Minutes 15)                        OK got: 0
02_datatypes_1     | minutes (Minutes 43)                      OK got: 43
02_datatypes_1     | seconds (Minutes 53)                      OK got: 3180
02_datatypes_1     | timeDistance (Minutes 15) (Minutes 25)    OK got: Minutes 10
02_datatypes_1     | timeDistance (Minutes 99) (Minutes 47)    OK got: Minutes 52
02_datatypes_1     | pointDistance (1, 1) (1, 3)               OK got: 2.0
02_datatypes_1     | pointDistance (3, 4) (0, 0)               OK got: 5.0
02_datatypes_1     | make: Leaving directory '/google/trainings/haskell/02_datatypes'
codelab_02_datatypes_1 exited with code 0
```

## 🩹 Preserved Container coloring - `when in docker-compose`

* This is a known issue when running containers whose logs are colored
  * https://github.com/docker/compose/issues/2231#issuecomment-425135985
* As the underlying testing "framework" built in haskell explicitly added to get colored test results 
  * Without them, that may also be a problem for some (me included)

![Screen Shot 2022-01-11 at 9 21 55 AM](https://user-images.githubusercontent.com/131457/148991413-7a040443-f506-4767-94a0-5fcfe07a6040.png)

# ⚡ Performance improvements 🐳 

Created a single Makefile from a copy of setup, made it pull dependencies.
That way, it's simpler for users to just run the docker container without
having to re-run the entire process over and over again. Instead, taking
advantage of the docker caching system by declaring a new layer in the
Dockerfile to call the dependencies only.

## 💩 Inefficient runs

All the time running the current code the build pulls everything over
and over again. That's just too much after a while. We have 2 options:

1. Create a base docker image for everything
2. Reuse the same `Dockerfile` for the same docker image
  * Updating the `Makefile` with a new task to get the dependencies
  * Run the dependencies for each of them

Since dependencies don't change often, the docker image cache works
perfectly to just pull the same dependencies for codecolab's functions
and the execution is left as is. This time, faster as it takes advantage
of the dependencies already built into the docker image instead of
the docker container (that is, the current version).

## 🔉 Docker Build - Cached Dependencies 

```console
$ docker-compose build
Building 00_setup
[+] Building 25.2s (10/10) FINISHED
=> [internal] load build definition from Dockerfile                                                                                                                      0.0s
=> => transferring dockerfile: 447B                                                                                                                                      0.0s
=> [internal] load .dockerignore                                                                                                                                         0.0s
=> => transferring context: 2B                                                                                                                                           0.0s
=> [internal] load metadata for registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                         0.0s
=> [1/5] FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                                           0.0s
=> [internal] load build context                                                                                                                                         0.0s
=> => transferring context: 22.73kB                                                                                                                                      0.0s
=> CACHED [2/5] WORKDIR /google/trainings/haskell                                                                                                                        0.0s
=> [3/5] COPY . .                                                                                                                                                        0.3s
=> [4/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                                                    0.3s
=> [5/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                                                24.0s
=> exporting to image                                                                                                                                                    0.5s
=> => exporting layers                                                                                                                                                   0.5s
=> => writing image sha256:f6156b012651ed2d5fa4ac33aff3a74b723616f3bf8c725d3da2b8cdb92b9c54                                                                              0.0s
=> => naming to docker.io/google/haskell-trainings                                                                                                                       0.0s
Building 01_functions
[+] Building 0.2s (10/10) FINISHED
=> [internal] load build definition from Dockerfile                                                                                                                      0.0s
=> => transferring dockerfile: 37B                                                                                                                                       0.0s
=> [internal] load .dockerignore                                                                                                                                         0.0s
=> => transferring context: 2B                                                                                                                                           0.0s
=> [internal] load metadata for registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                         0.0s
=> [1/5] FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                                           0.0s
=> [internal] load build context                                                                                                                                         0.0s
=> => transferring context: 19.82kB                                                                                                                                      0.0s
=> CACHED [2/5] WORKDIR /google/trainings/haskell                                                                                                                        0.0s
=> CACHED [3/5] COPY . .                                                                                                                                                 0.0s
=> CACHED [4/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                                             0.0s
=> CACHED [5/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                                          0.0s
=> exporting to image                                                                                                                                                    0.0s
=> => exporting layers                                                                                                                                                   0.0s
=> => writing image sha256:f6156b012651ed2d5fa4ac33aff3a74b723616f3bf8c725d3da2b8cdb92b9c54                                                                              0.0s
=> => naming to docker.io/google/haskell-trainings                                                                                                                       0.0s
Building 02_datatypes
[+] Building 0.2s (10/10) FINISHED
=> [internal] load build definition from Dockerfile                                                                                                                      0.0s
=> => transferring dockerfile: 37B                                                                                                                                       0.0s
=> [internal] load .dockerignore                                                                                                                                         0.0s
=> => transferring context: 2B                                                                                                                                           0.0s
=> [internal] load metadata for registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                         0.0s
=> [1/5] FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                                           0.0s
=> [internal] load build context                                                                                                                                         0.0s
=> => transferring context: 19.82kB                                                                                                                                      0.0s
=> CACHED [2/5] WORKDIR /google/trainings/haskell                                                                                                                        0.0s
=> CACHED [3/5] COPY . .                                                                                                                                                 0.0s
=> CACHED [4/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                                             0.0s
=> CACHED [5/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                                          0.0s
=> exporting to image                                                                                                                                                    0.0s
=> => exporting layers                                                                                                                                                   0.0s
=> => writing image sha256:f6156b012651ed2d5fa4ac33aff3a74b723616f3bf8c725d3da2b8cdb92b9c54                                                                              0.0s
=> => naming to docker.io/google/haskell-trainings                                                                                                                       0.0s
Building 03_lists
[+] Building 0.2s (10/10) FINISHED
=> [internal] load build definition from Dockerfile                                                                                                                      0.0s
=> => transferring dockerfile: 37B                                                                                                                                       0.0s
=> [internal] load .dockerignore                                                                                                                                         0.0s
=> => transferring context: 2B                                                                                                                                           0.0s
=> [internal] load metadata for registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                         0.0s
=> [1/5] FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                                           0.0s
=> [internal] load build context                                                                                                                                         0.0s
=> => transferring context: 19.82kB                                                                                                                                      0.0s
=> CACHED [2/5] WORKDIR /google/trainings/haskell                                                                                                                        0.0s
=> CACHED [3/5] COPY . .                                                                                                                                                 0.0s
=> CACHED [4/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                                             0.0s
=> CACHED [5/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                                          0.0s
=> exporting to image                                                                                                                                                    0.0s
=> => exporting layers                                                                                                                                                   0.0s
=> => writing image sha256:f6156b012651ed2d5fa4ac33aff3a74b723616f3bf8c725d3da2b8cdb92b9c54                                                                              0.0s
=> => naming to docker.io/google/haskell-trainings                                                                                                                       0.0s
Building 04_abstractions
[+] Building 0.2s (10/10) FINISHED
=> [internal] load build definition from Dockerfile                                                                                                                      0.0s
=> => transferring dockerfile: 37B                                                                                                                                       0.0s
=> [internal] load .dockerignore                                                                                                                                         0.0s
=> => transferring context: 2B                                                                                                                                           0.0s
=> [internal] load metadata for registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                         0.0s
=> [1/5] FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                                           0.0s
=> [internal] load build context                                                                                                                                         0.0s
=> => transferring context: 19.82kB                                                                                                                                      0.0s
=> CACHED [2/5] WORKDIR /google/trainings/haskell                                                                                                                        0.0s
=> CACHED [3/5] COPY . .                                                                                                                                                 0.0s
=> CACHED [4/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                                             0.0s
=> CACHED [5/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                                          0.0s
=> exporting to image                                                                                                                                                    0.0s
=> => exporting layers                                                                                                                                                   0.0s
=> => writing image sha256:f6156b012651ed2d5fa4ac33aff3a74b723616f3bf8c725d3da2b8cdb92b9c54                                                                              0.0s
=> => naming to docker.io/google/haskell-trainings                                                                                                                       0.0s
Building 05_maybe
[+] Building 0.4s (10/10) FINISHED
=> [internal] load build definition from Dockerfile                                                                                                                      0.0s
=> => transferring dockerfile: 37B                                                                                                                                       0.0s
=> [internal] load .dockerignore                                                                                                                                         0.0s
=> => transferring context: 2B                                                                                                                                           0.0s
=> [internal] load metadata for registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                         0.0s
=> [1/5] FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                                           0.0s
=> [internal] load build context                                                                                                                                         0.0s
=> => transferring context: 19.82kB                                                                                                                                      0.0s
=> CACHED [2/5] WORKDIR /google/trainings/haskell                                                                                                                        0.0s
=> CACHED [3/5] COPY . .                                                                                                                                                 0.0s
=> CACHED [4/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                                             0.0s
=> CACHED [5/5] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                                          0.0s
=> exporting to image                                                                                                                                                    0.1s
=> => exporting layers                                                                                                                                                   0.0s
=> => writing image sha256:f6156b012651ed2d5fa4ac33aff3a74b723616f3bf8c725d3da2b8cdb92b9c54                                                                              0.1s
=> => naming to docker.io/google/haskell-trainings                                                                                                                       0.0s
Building 06_rps
[+] Building 0.2s (10/10) FINISHED
=> [internal] load build definition from Dockerfile                                                                                                                      0.0s
=> => transferring dockerfile: 37B                                                                                                                                       0.0s
=> [internal] load .dockerignore                                                                                                                                         0.0s
=> => transferring context: 2B                                                                                                                                           0.0s
=> [internal] load metadata for registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                         0.0s
=> [1/5] FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                                           0.0s
4   image: google/haskell-trainings
```

# 👍 Faster solution

## 🔉 Build Logs

* All the dependencies are fetched during the docker image build
  * Where the goodies of docker image cache helps us with multiple executions

```console
☁️  aws-cli@2.2.32 🔖 aws-iam-authenticator@0.5.3
☸️  kubectl@1.22.4 📛 kustomize@v4.3.0 🎡 helm@3.7.0 👽 argocd@2.2.0 ✈️  glooctl@1.9.0 🐳 docker@20.10.11 🐙 docker-compose@1.29.2
👤 AWS_PS1_PROFILE 🗂️   🌎 sa-east-1
🏗  1.21.2-eks-0389ca3 🔐 arn:aws:eks:sa-east-1:806101772216:cluster/eks-ppd-prd-super-cash 🍱 default
~/dev/github.com/marcellodesales/haskell-trainings/haskell_101/codelab on  feature/feature/solving-02_datatypes! 📅 01-10-2022 ⌚15:49:49
$ docker-compose up 00_setup
Starting codelab_00_setup_1 ... done
Attaching to codelab_00_setup_1
00_setup_1         | make: Entering directory '/google/trainings/haskell/00_setup'
00_setup_1         | ============================================
00_setup_1         |
00_setup_1         | Haskell toolchain is installed! All is good.
00_setup_1         |
00_setup_1         | ============================================
00_setup_1         | make: Leaving directory '/google/trainings/haskell/00_setup'
codelab_00_setup_1 exited with code 0

☁️  aws-cli@2.2.32 🔖 aws-iam-authenticator@0.5.3
☸️  kubectl@1.22.4 📛 kustomize@v4.3.0 🎡 helm@3.7.0 👽 argocd@2.2.0 ✈️  glooctl@1.9.0 🐳 docker@20.10.11 🐙 docker-compose@1.29.2
👤 AWS_PS1_PROFILE 🗂️   🌎 sa-east-1
🏗  1.21.2-eks-0389ca3 🔐 arn:aws:eks:sa-east-1:806101772216:cluster/eks-ppd-prd-super-cash 🍱 default
~/dev/github.com/marcellodesales/haskell-trainings/haskell_101/codelab on  feature/feature/solving-02_datatypes! 📅 01-10-2022 ⌚15:50:19
$ docker-compose up 01_functions
Starting codelab_01_functions_1 ... done
Attaching to codelab_01_functions_1
01_functions_1     | make: Entering directory '/google/trainings/haskell/01_functions'
01_functions_1     | add       1 2                             OK got: 3
01_functions_1     | subtract  7 2                             OK got: 5
01_functions_1     | double    3                               OK got: 6
01_functions_1     | multiply  3 11                            OK got: 33
01_functions_1     | divide    9 2                             OK got: 4.5
01_functions_1     | divide    8 4                             OK got: 2.0
01_functions_1     | factorial 30                              OK got: 265252859812191058636308480000000
01_functions_1     | gcd       12 4                            OK got: 4
01_functions_1     | gcd       17 7                            OK got: 1
01_functions_1     | make: Leaving directory '/google/trainings/haskell/01_functions'
codelab_01_functions_1 exited with code 0
```

* We don't see the previous download of the dependencies anymore

```console
$ docker-compose up --build 02_datatypes
Building 02_datatypes
[+] Building 2.2s (18/18) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                         0.0s
 => => transferring dockerfile: 37B                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                            0.0s
 => => transferring context: 2B                                                                                                                              0.0s
 => resolve image config for docker.io/docker/dockerfile:1.2                                                                                                 0.4s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                            0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                             0.0s
 => [internal] load metadata for registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                            0.0s
 => [internal] load build context                                                                                                                            0.0s
 => => transferring context: 21.11kB                                                                                                                         0.0s
 => [stage-1 1/7] FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8.10.7_13057207-master                                      0.0s
 => [dependencies 1/3] FROM docker.io/library/alpine                                                                                                         0.0s
 => CACHED [dependencies 2/3] WORKDIR /google/trainings/haskell/cabal                                                                                        0.0s
 => [dependencies 3/3] RUN --mount=type=bind,target=/docker-context     cd /docker-context/;     find . -type f ( -iname *.cabal -o -iname *.yaml* ) -minde  0.3s
 => CACHED [stage-1 2/7] WORKDIR /google/trainings/haskell                                                                                                   0.0s
 => CACHED [stage-1 3/7] COPY --from=dependencies /google/trainings/haskell/cabal .                                                                          0.0s
 => CACHED [stage-1 4/7] COPY Makefile .                                                                                                                     0.0s
 => CACHED [stage-1 5/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} cp $(pwd)/Makefile $(pwd)/{}                                                        0.0s
 => CACHED [stage-1 6/7] RUN ls -d */ | awk '{ print $1 }' | xargs -I {} make -C {} deps                                                                     0.0s
 => [stage-1 7/7] COPY . .                                                                                                                                   0.3s
 => exporting to image                                                                                                                                       0.6s
 => => exporting layers                                                                                                                                      0.6s
 => => writing image sha256:e5ad5c0e73cd820d8bb974453af0da50211583482282947b2f3e7ad616036644                                                                 0.0s
 => => naming to docker.io/google/haskell-trainings                                                                                                          0.0s
Recreating codelab_02_datatypes_1 ... done
Attaching to codelab_02_datatypes_1
02_datatypes_1     | make: Entering directory '/google/trainings/haskell/02_datatypes'
02_datatypes_1     | codelab> configure (exe)
02_datatypes_1     | Configuring codelab-0.1.0.0...
02_datatypes_1     | codelab> build (exe)
02_datatypes_1     | Preprocessing executable 'codelab' for codelab-0.1.0.0..
02_datatypes_1     | Building executable 'codelab' for codelab-0.1.0.0..
02_datatypes_1     | [2 of 3] Compiling Codelab
02_datatypes_1     | [3 of 3] Compiling Main
02_datatypes_1     | Linking .stack-work/dist/x86_64-linux/Cabal-3.2.1.0/build/codelab/codelab ...
02_datatypes_1     | codelab> copy/register
02_datatypes_1     | Installing executable codelab in /google/trainings/haskell/02_datatypes/.stack-work/install/x86_64-linux/b75127df98e825dd26b7ce71e8ebbb670312dcae0b6d352496233a58a9f2a774/8.10.7/bin
02_datatypes_1     | Installing executable solution in /google/trainings/haskell/02_datatypes/.stack-work/install/x86_64-linux/b75127df98e825dd26b7ce71e8ebbb670312dcae0b6d352496233a58a9f2a774/8.10.7/bin
02_datatypes_1     | hours (Minutes 271)                       OK got: 4
02_datatypes_1     | hours (Minutes 15)                        OK got: 0
02_datatypes_1     | minutes (Minutes 43)                      OK got: 43
02_datatypes_1     | seconds (Minutes 53)                      OK got: 3180
02_datatypes_1     | timeDistance (Minutes 15) (Minutes 25)    OK got: Minutes 10
02_datatypes_1     | timeDistance (Minutes 99) (Minutes 47)    OK got: Minutes 52
02_datatypes_1     | pointDistance (1, 1) (1, 3)               OK got: 2.0
02_datatypes_1     | pointDistance (3, 4) (0, 0)               OK got: 5.0
02_datatypes_1     | make: Leaving directory '/google/trainings/haskell/02_datatypes'
codelab_02_datatypes_1 exited with code 0
```

