### PR TITLE
Feature/add dockerized pipeline

### DIFF
--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -18,9 +18,6 @@ on:
 
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables
 env:
-  # https://github.com/actions/starter-workflows/issues/68#issuecomment-524665878
-  DOCKER_IMAGE_TAG: "docker.pkg.github.com/${GITHUB_REPOSITORY}/${GITHUB_REF##*/}:${GITHUB_SHA}"
-
   DOCKER_CONTEXT_PATH: "haskell_101/codelab"
   IMAGE_NAME_SUFFIX: haskell_101
 
@@ -36,11 +33,22 @@ jobs:
     container:
       image: docker/compose:1.29.2
 
+    # https://github.community/t/sharing-a-variable-between-jobs/16967/14
+    outputs:
+      imageNameSuffix: ${{steps.set-base-values.outputs.imageNameSuffix}}
+      dockerContextPath: ${{steps.set-base-values.outputs.dockerContextPath}}
+      defaultDockerImageRepo: ${{steps.set-base-values.outputs.defaultDockerImageRepo}}
+      defaultDockerImageVersion: ${{steps.set-base-values.outputs.defaultDockerImageVersion}}
+      defaultDockerImageBranchTag: ${{steps.set-base-values.outputs.defaultDockerImageBranchTag}}
+
     steps:
       - name: Set default envs from the env above
         run: |
            echo "IMAGE_NAME_SUFFIX=${{env.IMAGE_NAME_SUFFIX}}" >> $GITHUB_ENV
            echo "DOCKER_CONTEXT_PATH=${{env.DOCKER_CONTEXT_PATH}}" >> $GITHUB_ENV
+           # registry has renamed: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry
+           echo "DEFAULT_DOCKER_IMAGE_REPO=ghcr.io/${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+           echo "DEFAULT_DOCKER_IMAGE_VERSION=${IMAGE_NAME_SUFFIX}-${GITHUB_SHA}" >> $GITHUB_ENV
 
       - name: Parse and set the github repo name for the docker image
         run: |
@@ -49,6 +57,22 @@ jobs:
       - name: Parse and set the docker repo name
         run: |
            echo "PUBLIC_DOCKER_REPO=$(echo ${GITHUB_REPOSITORY} | sed 's/-docker//g' | sed 's/docker-//g' )" >> $GITHUB_ENV
+
+      - id: set-base-values
+        # The below outputs a JSON array of check tasks for each subproject
+        #  and uses GitHub Actions magic (::set-output) to set an output
+        #  variable https://www.cynkra.com/blog/2020-12-23-dynamic-gha/
+        # https://github.community/t/sharing-a-variable-between-jobs/16967/14
+        run: |
+          BRANCH_TAG=${IMAGE_NAME_SUFFIX}-$(echo ${GITHUB_SHA} |  cut -c1-7)-${GITHUB_REF##*/}
+          echo "Branch tag to use: ${BRANCH_TAG}"
+
+          echo "Setting the value of the image suffix: ${{env.IMAGE_NAME_SUFFIX}}"
+          echo "::set-output name=imageNameSuffix::$IMAGE_NAME_SUFFIX"
+          echo "::set-output name=dockerContextPath::$DOCKER_CONTEXT_PATH"
+          echo "::set-output name=defaultDockerImageRepo::$DEFAULT_DOCKER_IMAGE_REPO"
+          echo "::set-output name=defaultDockerImageVersion::$DEFAULT_DOCKER_IMAGE_VERSION"
+          echo "::set-output name=defaultDockerImageBranchTag::$BRANCH_TAG"
 
   build:
     name: Build Docker Image with Haskell Training-101
@@ -60,7 +84,7 @@ jobs:
    # Declare our output variable https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      container_name: ${{ steps.set-compose_image_name.outputs.image_name }}
+      image_name: ${{ steps.set-compose_image_name.outputs.image_name }}
 
     steps:
       - name: Fetch only the top commit
@@ -195,26 +219,56 @@ jobs:
 
   deploy:
     name: Tag and Push the docker images
-    needs: build
+    # https://stackoverflow.com/questions/63148639/create-dependencies-between-jobs-in-github-actions/63148947#63148947
+    # https://github.community/t/sharing-a-variable-between-jobs/16967/14
+    needs: [setup, build]
     runs-on: ubuntu-latest
     container:
       image: docker/compose:1.29.2
 
     steps:
+      # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions
+      - name: Show all outputs
+        run: |
+          echo "Output key: needs.setup.outputs.defaultDockerImageRepo=${{needs.setup.outputs.defaultDockerImageRepo}}"
+          echo "Output key: needs.setup.outputs.defaultDockerImageVersion=${{needs.setup.outputs.defaultDockerImageVersion}}"
+          echo "Output key: needs.setup.outputs.defaultDockerImageBranchTag=${{needs.setup.outputs.defaultDockerImageBranchTag}}"
+
+      - name: Download built training-image
+        uses: actions/download-artifact@v2
+        with:
+          name: training-image
+
+      - name: Load Docker Image Binary for cache
+        run: |
+          ls -la ${{env.LOCAL_IMAGE_BIN_NAME}}
+          docker load -i ${{env.LOCAL_IMAGE_BIN_NAME}}
+
+      - name: List the docker images locally
+        run: |
+          docker images
+
       # https://github.com/marcellodesales/cloner/packages?package_type=Docker
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_GITHUB_TOKEN }}
 
-      - name: Tag & Push the docker-compose image '${{needs.build.outputs.image_name}}' as '${{env.DOCKER_IMAGE_TAG}}'
-        run: docker tag ${{needs.build.outputs.image_name}} ${{env.DOCKER_IMAGE_TAG}}
+      # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions
+      - name: Tag & Push SHA docker-compose image '${{needs.build.outputs.image_name}}' as '${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}}'
+        run: |
+          docker tag ${{needs.build.outputs.image_name}} ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}}
+          docker push ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}}
 
-      - name: Tag & Push the docker-compose image '${{needs.build.outputs.image_name}}' as 'docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_REF##*/}'
-        run: docker tag ${{needs.build.outputs.image_name}} docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_REF##*/}
+      - name: Tag & Push BRANCH docker-compose image '${{needs.build.outputs.image_name}}' as '${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchTag}}'
+        run: |
+          docker tag ${{needs.build.outputs.image_name}} ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchTag}}
+          docker push ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchTag}}
 
-      - name: Tag & Push the docker-compose image '${{needs.build.outputs.image_name}}' as 'docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:latest'
-        if: endsWith(github.ref, '/main') || endsWith(github.ref, '/master')
-        run: docker ${{needs.build.outputs.image_name}} docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:latest
+      - if: endsWith(github.ref, '/main') || endsWith(github.ref, '/master')
+        name: Tag & Push LATEST docker-compose image '${{needs.build.outputs.image_name}}' as '${{needs.setup.outputs.defaultDockerImageRepo}}:latest'
+        run: |
+          docker tag ${{needs.build.outputs.image_name}} ${{steps.setup.outputs.defaultDockerImageRepo}}:latest
+          docker push ${{steps.setup.outputs.defaultDockerImageRepo}}:latest

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -87,10 +87,12 @@ jobs:
 
       - name: Saving the built docker image as a local file
         run: |
-          echo "Saving the image locally..."
+          echo "Saving the image locally at dir ${{env.LOCAL_IMAGE_BIN_PATH}}"
+          mkdir ${{env.LOCAL_IMAGE_BIN_PATH}}
           docker save -o ${{env.LOCAL_IMAGE_BIN_PATH}}/${{env.LOCAL_IMAGE_BIN_NAME}} ${COMPOSE_IMAGE_NAME}
 
           ls -la ${{env.LOCAL_IMAGE_BIN_PATH}}/${{env.LOCAL_IMAGE_BIN_NAME}}
+          ls -lah ${{env.LOCAL_IMAGE_BIN_PATH}}/${{env.LOCAL_IMAGE_BIN_NAME}}
 
       - name: Upload Docker Image to pipelie artifacts
         uses: actions/upload-artifact@v2
@@ -113,7 +115,7 @@ jobs:
 
       - name: Load Docker Image Binary for cache
         run: |
-          ls -la ${{env.LOCAL_IMAGE_BIN_PATH}}/${{env.LOCAL_IMAGE_BIN_NAME}}
+          ls -la ${{env.LOCAL_IMAGE_BIN_NAME}}
           docker load -i ${{env.LOCAL_IMAGE_BIN_NAME}}
 
       - name: List the docker images locally

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -85,15 +85,24 @@ jobs:
         #  and uses GitHub Actions magic (::set-output) to set an output
         #  variable https://www.cynkra.com/blog/2020-12-23-dynamic-gha/
         run: |
-          ls -lar
-          EXERCISES=$(find ${{env.DOCKER_CONTEXT_PATH}} -maxdepth 1 -type d -exec echo {} +;)
-          GITHUB_MATRIX_PACKAGES=$(echo '{ "package" : ['
-            echo $EXERCISES | sed 's/ /, /g' | xargs -n 1 echo | tail -n +2 | awk -F"/" '{print $3}' | sed -r 's/^([^,]*)(,?)$/"\1"\2/'
-          echo "]}")
+          #ls -lar
+          # https://stackoverflow.com/questions/22434290/jq-bash-make-json-array-from-variable/54576004#54576004
+          cd ${{env.DOCKER_CONTEXT_PATH}}
+
+          # Get the keys in docker-compose https://stackoverflow.com/questions/23118341/how-to-get-key-names-from-json-using-jq/23118607#23118607
+          EXERCISES=$(docker-compose config | docker run --rm -i mikefarah/yq e . - -o json | docker run --rm -i imega/jq -r -c '.services | keys')
+
+          # Convert them into the matrix object
+          GITHUB_MATRIX_PACKAGES=$(echo $EXERCISES | docker run --rm -i imega/jq '. | sort' | docker run --rm -i imega/jq -c '{"package": .}')
           echo "Dynamic github matrix packages: ${GITHUB_MATRIX_PACKAGES}"
 
+          # Build a matrix of values to generate parallel stages, one for each exercise
+          # https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
+          # https://rnorth.org/faster-parallel-github-builds/
+          # https://www.cynkra.com/blog/2020-12-23-dynamic-gha/
+          # https://github.com/r-dbi/DBItest/blob/main/.github/workflows/backends.yaml
           echo "Setting the value as the matrix..."
-          echo "::set-output name=matrix::${GITHUB_MATRIX_PACKAGES}"
+          echo "::set-output name=matrix::$GITHUB_MATRIX_PACKAGES"
 
       - name: Build docker image
         # https://stackoverflow.com/questions/55756372/when-using-buildkit-with-docker-how-do-i-see-the-output-of-run-commands/55759337#55759337
@@ -135,7 +144,7 @@ jobs:
       matrix: ${{fromJson(needs.build.outputs.matrix)}}
 
     steps:
-      - name: Download artifact cloner.dockerimage
+      - name: Download built training-image
         uses: actions/download-artifact@v2
         with:
           name: training-image
@@ -155,7 +164,9 @@ jobs:
           fetch-depth: 1
 
       - name: Show cloned files structure
-        run: docker container run --rm -v $(pwd):$(pwd) iankoulski/tree $(pwd)
+        run: |
+          docker container run --rm -v $(pwd):$(pwd) iankoulski/tree $(pwd)
+          ls -lar
 
       - name: Run ${{matrix.package}} tests
         # https://stackoverflow.com/questions/55756372/when-using-buildkit-with-docker-how-do-i-see-the-output-of-run-commands/55759337#55759337
@@ -164,12 +175,11 @@ jobs:
           cd ${{env.DOCKER_CONTEXT_PATH}}
 
           echo "Since the image is already built and loaded: docker-compose: ${COMPOSE_IMAGE_NAME} ${{matrix.package}}"
-          docker-compose up ${{matrix.package}} --exit-code-from
-          docker-compose up --exit-code-from ${{matrix.package}}
+          docker-compose run ${{matrix.package}}
 
   deploy:
     name: Tag and Push the docker images
-    needs: test
+    needs: build
     runs-on: ubuntu-latest
     container:
       image: docker/compose:1.29.2

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -57,6 +57,10 @@ jobs:
     container:
       image: docker/compose:1.29.2
 
+   # Declare our output variable https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
     steps:
       - name: Fetch only the top commit
         uses: actions/checkout@v2
@@ -72,7 +76,26 @@ jobs:
           password: ${{ secrets.REGISTRY_GITLAB_TOKEN }}
 
       - name: Show cloned files scructure
-        run: docker container run --rm -v $(pwd):$(pwd) iankoulski/tree $(pwd)
+        run: |
+          docker container run --rm -v $(pwd):$(pwd) iankoulski/tree $(pwd)
+          ls -lar
+
+      - id: set-matrix
+        # The below outputs a JSON array of check tasks for each subproject
+        #  and uses GitHub Actions magic (::set-output) to set an output
+        #  variable https://www.cynkra.com/blog/2020-12-23-dynamic-gha/
+        run: |
+          ls -lar
+          EXERCISES=$(find ${{env.DOCKER_CONTEXT_PATH}} -maxdepth 1 -type d -exec echo {} +;)
+          EXERCISES=$(echo $EXERCISES | tr " " "\n" | tail -n +2 | awk -F"/" '{print $3}')
+          echo "List of exercises: ${EXERCISES}"
+
+          GITHUB_MATRIX_PACKAGES=$(docker run --rm -i imega/jq -nc '{package: $ARGS.positional[0] | split("\n")}' --args ${EXERCISES[@]})
+          echo "Dynamic github matrix packages"
+          echo ${GITHUB_MATRIX_PACKAGES} | docker run --rm -i imega/jq .
+
+          echo "Setting the value as the matrix..."
+          echo "::set-output name=matrix::${GITHUB_MATRIX_PACKAGES}"
 
       - name: Build docker image
         # https://stackoverflow.com/questions/55756372/when-using-buildkit-with-docker-how-do-i-see-the-output-of-run-commands/55759337#55759337
@@ -107,6 +130,12 @@ jobs:
     container:
       image: docker/compose:1.29.2
 
+    # Composite github : https://stackoverflow.com/questions/65242830/in-a-github-actions-workflow-is-there-a-way-to-have-multiple-jobs-reuse-the-sam/65243912#65243912
+    # Just use a matrix to run the tests for each individual exercise
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.build.outputs.matrix)}}
+
     steps:
       - name: Download artifact cloner.dockerimage
         uses: actions/download-artifact@v2
@@ -127,17 +156,18 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Show cloned files scructure
+      - name: Show cloned files structure
         run: docker container run --rm -v $(pwd):$(pwd) iankoulski/tree $(pwd)
 
-      - name: Run all tests in parallel
+      - name: Run ${{matrix.package}} tests
         # https://stackoverflow.com/questions/55756372/when-using-buildkit-with-docker-how-do-i-see-the-output-of-run-commands/55759337#55759337
         run: |
           echo "Building the context dir ${{env.DOCKER_CONTEXT_PATH}}"
           cd ${{env.DOCKER_CONTEXT_PATH}}
 
-          echo "Since the image is already built and loaded, we can just run... docker-compose: ${COMPOSE_IMAGE_NAME}"
-          docker-compose up
+          echo "Since the image is already built and loaded: docker-compose: ${COMPOSE_IMAGE_NAME} ${{matrix.package}}"
+          docker-compose up ${{matrix.package}} --exit-code-from
+          docker-compose up --exit-code-from ${{matrix.package}}
 
   deploy:
     name: Tag and Push the docker images

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -133,6 +133,9 @@ jobs:
       - name: Run all tests in parallel
         # https://stackoverflow.com/questions/55756372/when-using-buildkit-with-docker-how-do-i-see-the-output-of-run-commands/55759337#55759337
         run: |
+          echo "Building the context dir ${{env.DOCKER_CONTEXT_PATH}}"
+          cd ${{env.DOCKER_CONTEXT_PATH}}
+
           echo "Since the image is already built and loaded, we can just run... docker-compose: ${COMPOSE_IMAGE_NAME}"
           docker-compose up
 

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -35,8 +35,6 @@ jobs:
 
     # https://github.community/t/sharing-a-variable-between-jobs/16967/14
     outputs:
-      imageNameSuffix: ${{steps.set-base-values.outputs.imageNameSuffix}}
-      dockerContextPath: ${{steps.set-base-values.outputs.dockerContextPath}}
       defaultDockerImageRepo: ${{steps.set-base-values.outputs.defaultDockerImageRepo}}
       defaultDockerImageVersion: ${{steps.set-base-values.outputs.defaultDockerImageVersion}}
       defaultDockerImageBranchTag: ${{steps.set-base-values.outputs.defaultDockerImageBranchTag}}
@@ -47,16 +45,8 @@ jobs:
            echo "IMAGE_NAME_SUFFIX=${{env.IMAGE_NAME_SUFFIX}}" >> $GITHUB_ENV
            echo "DOCKER_CONTEXT_PATH=${{env.DOCKER_CONTEXT_PATH}}" >> $GITHUB_ENV
            # registry has renamed: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry
-           echo "DEFAULT_DOCKER_IMAGE_REPO=ghcr.io/${GITHUB_REPOSITORY}" >> $GITHUB_ENV
-           echo "DEFAULT_DOCKER_IMAGE_VERSION=${IMAGE_NAME_SUFFIX}-${GITHUB_SHA}" >> $GITHUB_ENV
-
-      - name: Parse and set the github repo name for the docker image
-        run: |
-           echo "GITHUB_IMAGE_REPO_NAME=$(echo ${GITHUB_REPOSITORY} | awk -F'/' '{ print $2 }' )-${{env.IMAGE_NAME_SUFFIX}}" >> $GITHUB_ENV
-
-      - name: Parse and set the docker repo name
-        run: |
-           echo "PUBLIC_DOCKER_REPO=$(echo ${GITHUB_REPOSITORY} | sed 's/-docker//g' | sed 's/docker-//g' )" >> $GITHUB_ENV
+           echo "DEFAULT_DOCKER_IMAGE_REPO=ghcr.io/${GITHUB_REPOSITORY}/${IMAGE_NAME_SUFFIX}" >> $GITHUB_ENV
+           echo "DEFAULT_DOCKER_IMAGE_VERSION=${GITHUB_SHA}" >> $GITHUB_ENV
 
       - id: set-base-values
         # The below outputs a JSON array of check tasks for each subproject
@@ -67,9 +57,6 @@ jobs:
           BRANCH_TAG=${IMAGE_NAME_SUFFIX}-$(echo ${GITHUB_SHA} |  cut -c1-7)-${GITHUB_REF##*/}
           echo "Branch tag to use: ${BRANCH_TAG}"
 
-          echo "Setting the value of the image suffix: ${{env.IMAGE_NAME_SUFFIX}}"
-          echo "::set-output name=imageNameSuffix::$IMAGE_NAME_SUFFIX"
-          echo "::set-output name=dockerContextPath::$DOCKER_CONTEXT_PATH"
           echo "::set-output name=defaultDockerImageRepo::$DEFAULT_DOCKER_IMAGE_REPO"
           echo "::set-output name=defaultDockerImageVersion::$DEFAULT_DOCKER_IMAGE_VERSION"
           echo "::set-output name=defaultDockerImageBranchTag::$BRANCH_TAG"
@@ -128,6 +115,21 @@ jobs:
           # https://github.com/r-dbi/DBItest/blob/main/.github/workflows/backends.yaml
           echo "Setting the value as the matrix..."
           echo "::set-output name=matrix::$GITHUB_MATRIX_PACKAGES"
+
+      # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+      # https://github.community/t/github-container-registry-ghcr-io-packages-not-appearing-in-webinterface/130077
+      - name: Associate Dockerfile to the repo
+        run: |
+          env
+          echo "IS THIS ${GITHUB_REPOSITORY}"
+          echo "In order to associate the docker image to the repo, we need to associate the Dockerfile to the repo"
+          export LABEL_VALUE=https://github.com/${GITHUB_REPOSITORY}
+          echo "Adding 'LABEL org.opencontainers.image.source ${LABEL_VALUE}' to Dockerfile"
+          
+          # Switch to the context dir and update all dockerfiles that will be used
+          cd ${{env.DOCKER_CONTEXT_PATH}}
+          # https://stackoverflow.com/questions/845863/how-to-use-in-an-xargs-command/70230514#70230514
+          find . -name 'Dockerfile' -print0 | xargs -0 grep -iL "org.opencontainers.image.source" | xargs -0 -I{} sh -c 'echo "LABEL org.opencontainers.image.source ${LABEL_VALUE}" >> {}' -- {}
 
       - name: Build docker image
         # https://stackoverflow.com/questions/55756372/when-using-buildkit-with-docker-how-do-i-see-the-output-of-run-commands/55759337#55759337

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -12,40 +12,59 @@ on:
       - hotfix/**
     paths-ignore:
       - '**/README.md' # https://stackoverflow.com/questions/62968897/is-it-possible-to-not-run-github-action-for-readme-updates/62972393#62972393
-  pull_request:
-    branches: [ master, develop, feature/**, bugfix/** ]
+
+#  pull_request:
+#    branches: [ master, develop, feature/**, bugfix/** ]
+
+# https://docs.github.com/en/actions/learn-github-actions/environment-variables
+env:
+  # https://github.com/actions/starter-workflows/issues/68#issuecomment-524665878
+  DOCKER_IMAGE_TAG: "docker.pkg.github.com/${GITHUB_REPOSITORY}/${GITHUB_REF##*/}:${GITHUB_SHA}"
+
+  DOCKER_CONTEXT_PATH: "haskell_101/codelab"
+  IMAGE_NAME_SUFFIX: haskell_101
+
+  LOCAL_IMAGE_BIN_NAME: training-docker-image
+  LOCAL_IMAGE_BIN_PATH: ./dist
 
 # https://faun.pub/building-a-ci-cd-pipeline-with-github-actions-and-docker-part-1-a9d8709c31fb
 jobs:
 
-  build:
-    name: Build CLI Binaries
-
+  setup:
+    name: Resolve variables and values
     runs-on: ubuntu-latest
-
     container:
       image: docker/compose:1.29.2
 
-    env:
-      DOCKER_IMAGE_TAG: "docker.pkg.github.com/${GITHUB_REPOSITORY}/${GITHUB_REF##*/}"
-      # https://github.com/actions/starter-workflows/issues/68#issuecomment-524665878
+    steps:
+      - name: Set default envs from the env above
+        run: |
+           echo "IMAGE_NAME_SUFFIX=${{env.IMAGE_NAME_SUFFIX}}" >> $GITHUB_ENV
+           echo "DOCKER_CONTEXT_PATH=${{env.DOCKER_CONTEXT_PATH}}" >> $GITHUB_ENV
 
-      DOCKER_CONTEXT_PATH: "haskell_101/codelab"
-      IMAGE_NAME_SUFFIX: haskell_101
+      - name: Parse and set the github repo name for the docker image
+        run: |
+           echo "GITHUB_IMAGE_REPO_NAME=$(echo ${GITHUB_REPOSITORY} | awk -F'/' '{ print $2 }' )-${{env.IMAGE_NAME_SUFFIX}}" >> $GITHUB_ENV
+
+      - name: Parse and set the docker repo name
+        run: |
+           echo "PUBLIC_DOCKER_REPO=$(echo ${GITHUB_REPOSITORY} | sed 's/-docker//g' | sed 's/docker-//g' )" >> $GITHUB_ENV
+
+  build:
+    name: Build CLI Binaries
+    needs: setup
+    runs-on: ubuntu-latest
+    container:
+      image: docker/compose:1.29.2
 
     steps:
-      - name: Repo Name
-        run: |
-           echo "GITHUB_IMAGE_REPO_NAME=$( echo ${GITHUB_REPOSITORY} | awk -F'/' '{ print $2 }' )-${{env.IMAGE_NAME_SUFFIX}}" >> $GITHUB_ENV
-
-      - name: Public Docker Repo Name
-        run: |
-           echo "PUBLIC_DOCKER_REPO=$( echo ${GITHUB_REPOSITORY} | sed 's/-docker//g' | sed 's/docker-//g' )" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v2
+      - name: Fetch only the top commit
+        uses: actions/checkout@v2
         with:
-          # https://github.com/actions/checkout/pull/258 needs to fetch all tags so that Makefile can make the correct version
-          fetch-depth: 0
+          fetch-depth: 1
+
+      - name: Show cloned files scructure
+        run: docker container run --rm -v $(pwd):$(pwd) iankoulski/tree $(pwd)
 
       - name: Build docker image
         # https://stackoverflow.com/questions/55756372/when-using-buildkit-with-docker-how-do-i-see-the-output-of-run-commands/55759337#55759337
@@ -54,21 +73,67 @@ jobs:
           cd ${{env.DOCKER_CONTEXT_PATH}}
 
           COMPOSE_IMAGE_NAME=$(docker-compose config | docker run --rm -i mikefarah/yq e . - -o json | docker run --rm -i imega/jq -r '.services | first(.[]).image')
-          echo "Building image from docker-compose: ${IMAGE_NAME}"
-
+          echo "COMPOSE_IMAGE_NAME=${COMPOSE_IMAGE_NAME}" >> $GITHUB_ENV
+          echo "Building image from docker-compose: ${COMPOSE_IMAGE_NAME}"
           docker-compose build
 
-          DEFAULT_REPO_IMAGE_TAG=docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA}
-          echo "Tagging the docker-compose image '${COMPOSE_IMAGE_NAME}' as '${DEFAULT_REPO_IMAGE_TAG}'"
-          docker tag ${COMPOSE_IMAGE_NAME} ${DEFAULT_REPO_IMAGE_TAG} 
+      - name: Saving the built docker image as a local file
+        run: |
+          echo "Saving the image locally..."
+          docker save -o ${{env.LOCAL_IMAGE_BIN_PATH}}/${{env.LOCAL_IMAGE_BIN_NAME}} ${COMPOSE_IMAGE_NAME}
 
-      - name: Tag with the branch name
-        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_REF##*/}
+          ls -la ${{env.LOCAL_IMAGE_BIN_PATH}}/${{env.LOCAL_IMAGE_BIN_NAME}}
 
-      - name: Tag the latest image
-        if: endsWith(github.ref, '/main')
-        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:latest
+      - name: Upload Docker Image to pipelie artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: training-image
+          path: ${{env.LOCAL_IMAGE_BIN_PATH}}/${{env.LOCAL_IMAGE_BIN_NAME}}
 
+  test:
+    needs: build
+    name: Testing
+    runs-on: ubuntu-latest
+    container:
+      image: docker/compose:1.29.2
+
+    steps:
+      - name: Download artifact cloner.dockerimage
+        uses: actions/download-artifact@v2
+        with:
+          name: training-image
+
+      - name: Load Docker Image Binary for cache
+        run: |
+          ls -la ${{env.LOCAL_IMAGE_BIN_PATH}}/${{env.LOCAL_IMAGE_BIN_NAME}}
+          docker load -i ${{env.LOCAL_IMAGE_BIN_NAME}}
+
+      - name: List the docker images locally
+        run: |
+          docker images
+
+      - name: Fetch only the top commit
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Show cloned files scructure
+        run: docker container run --rm -v $(pwd):$(pwd) iankoulski/tree $(pwd)
+
+      - name: Run all tests in parallel
+        # https://stackoverflow.com/questions/55756372/when-using-buildkit-with-docker-how-do-i-see-the-output-of-run-commands/55759337#55759337
+        run: |
+          echo "Since the image is already built and loaded, we can just run... docker-compose: ${COMPOSE_IMAGE_NAME}"
+          docker-compose up
+
+  push:
+    name: Tag and Push the docker images
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: docker/compose:1.29.2
+
+    steps:
       # https://github.com/marcellodesales/cloner/packages?package_type=Docker
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1
@@ -76,6 +141,16 @@ jobs:
           registry: docker.pkg.github.com
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_GITHUB_TOKEN }}
+
+      - name: Tagging the docker-compose image '${COMPOSE_IMAGE_NAME}' as '${DOCKER_IMAGE_TAG}'
+        run: docker tag ${COMPOSE_IMAGE_NAME} ${DEFAULT_REPO_IMAGE_TAG}
+
+      - name: Tag with the branch name
+        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_REF##*/}
+
+      - name: Tag the latest image
+        if: endsWith(github.ref, '/main')
+        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:latest
 
       # Publish the Branch Docker Images to Github Container Registry
       - name: Push latest Docker Image
@@ -87,38 +162,5 @@ jobs:
 
        # Publish the Sha  Docker Images to Github Container Registry
       - name: Push Docker Image latest from master
-        if: endsWith(github.ref, '/main')
+        if: endsWith(github.ref, '/main') || endsWith(github.ref, '/master')
         run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:latest
-
-      - name: Docker image to push
-        run: echo "Image repo is '${{env.PUBLIC_DOCKER_REPO}}'"
-
-      # https://github.com/marcellodesales/cloner/packages?package_type=Docker
-      - name: Login to Dockerhub Registry
-        uses: docker/login-action@v1
-        with:
-          #registry: docker.com
-          username: marcellodesales
-          password: ${{ secrets.REGISTRY_DOCKERHUB_TOKEN }}
-
-      - name: Tag the latest image in the public repo
-        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} ${{env.PUBLIC_DOCKER_REPO}}:${GITHUB_SHA}
-
-      - name: Tag the latest image in the public repo
-        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} ${{env.PUBLIC_DOCKER_REPO}}:${GITHUB_REF##*/}
-
-       # Latest version of image
-      - name: Docker Push the latest image
-        if: endsWith(github.ref, '/main') || endsWith(github.ref, '/master')
-        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} ${{env.PUBLIC_DOCKER_REPO}}
-
-      - name: Tag the latest image in the public repo
-        run: docker push ${{env.PUBLIC_DOCKER_REPO}}:${GITHUB_SHA}
-
-      - name: Tag the latest image in the public repo
-        run: docker push ${{env.PUBLIC_DOCKER_REPO}}:${GITHUB_REF##*/}
-
-       # Latest version of image
-      - name: Docker Push the latest image
-        if: endsWith(github.ref, '/main') || endsWith(github.ref, '/master')
-        run: docker push ${{env.PUBLIC_DOCKER_REPO}}

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -63,6 +63,14 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Login to Gitlab Container Registry to pull Haskell image
+        uses: docker/login-action@v1
+        with:
+          registry: registry.gitlab.com
+          # Resolves to this current user
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.REGISTRY_GITLAB_TOKEN }}
+
       - name: Show cloned files scructure
         run: docker container run --rm -v $(pwd):$(pwd) iankoulski/tree $(pwd)
 

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -38,6 +38,7 @@ jobs:
       defaultDockerImageRepo: ${{steps.set-base-values.outputs.defaultDockerImageRepo}}
       defaultDockerImageVersion: ${{steps.set-base-values.outputs.defaultDockerImageVersion}}
       defaultDockerImageBranchTag: ${{steps.set-base-values.outputs.defaultDockerImageBranchTag}}
+      defaultDockerImageBranchShaTag: ${{steps.set-base-values.outputs.defaultDockerImageBranchShaTag}}
 
     steps:
       - name: Set default envs from the env above
@@ -54,12 +55,17 @@ jobs:
         #  variable https://www.cynkra.com/blog/2020-12-23-dynamic-gha/
         # https://github.community/t/sharing-a-variable-between-jobs/16967/14
         run: |
-          BRANCH_TAG=${IMAGE_NAME_SUFFIX}-$(echo ${GITHUB_SHA} |  cut -c1-7)-${GITHUB_REF##*/}
-          echo "Branch tag to use: ${BRANCH_TAG}"
+          # The repo name only without refs
+          BRANCH_TAG=${GITHUB_REF##*/}
+
+          # The branch and sha together makes it easier to find
+          BRANCH_SHA_TAG=${BRANCH_TAG}-$(echo ${GITHUB_SHA} | cut -c1-7)
+          echo "Branch tag to use: ${BRANCH_TAG} and ${BRANCH_SHA_TAG}"
 
           echo "::set-output name=defaultDockerImageRepo::$DEFAULT_DOCKER_IMAGE_REPO"
           echo "::set-output name=defaultDockerImageVersion::$DEFAULT_DOCKER_IMAGE_VERSION"
           echo "::set-output name=defaultDockerImageBranchTag::$BRANCH_TAG"
+          echo "::set-output name=defaultDockerImageBranchShaTag::$BRANCH_SHA_TAG"
 
   build:
     name: Build Docker Image with Haskell Training-101
@@ -118,6 +124,7 @@ jobs:
 
       # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
       # https://github.community/t/github-container-registry-ghcr-io-packages-not-appearing-in-webinterface/130077
+      # Manually make the image public by going to the module's settings, Danger Zone
       - name: Associate Dockerfile to the repo
         run: |
           env
@@ -268,6 +275,11 @@ jobs:
         run: |
           docker tag ${{needs.build.outputs.image_name}} ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchTag}}
           docker push ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchTag}}
+
+      - name: Tag & Push BRANCH-SHA docker-compose image '${{needs.build.outputs.image_name}}' as '${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchShaTag}}'
+        run: |
+          docker tag ${{needs.build.outputs.image_name}} ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchShaTag}}
+          docker push ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchShaTag}}
 
       - if: endsWith(github.ref, '/main') || endsWith(github.ref, '/master')
         name: Tag & Push LATEST docker-compose image '${{needs.build.outputs.image_name}}' as '${{needs.setup.outputs.defaultDockerImageRepo}}:latest'

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -60,6 +60,7 @@ jobs:
    # Declare our output variable https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      container_name: ${{ steps.set-compose_image_name.outputs.image_name }}
 
     steps:
       - name: Fetch only the top commit
@@ -114,6 +115,21 @@ jobs:
           echo "COMPOSE_IMAGE_NAME=${COMPOSE_IMAGE_NAME}" >> $GITHUB_ENV
           echo "Building image from docker-compose: ${COMPOSE_IMAGE_NAME}"
           DOCKER_BUILDKIT=1 docker-compose build
+
+      - id: set-compose_image_name
+        # The below outputs a JSON array of check tasks for each subproject
+        #  and uses GitHub Actions magic (::set-output) to set an output
+        #  variable https://www.cynkra.com/blog/2020-12-23-dynamic-gha/
+        run: |
+          # Build a matrix of values to generate parallel stages, one for each exercise
+          # https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
+          # https://rnorth.org/faster-parallel-github-builds/
+          # https://www.cynkra.com/blog/2020-12-23-dynamic-gha/
+          # https://github.com/r-dbi/DBItest/blob/main/.github/workflows/backends.yaml
+          echo "Setting the value of the container image name: ${COMPOSE_IMAGE_NAME}"
+
+          # MAKE SURE TO NOT USE ${} in variables for set-output
+          echo "::set-output name=image_name::$COMPOSE_IMAGE_NAME"
 
       - name: Saving the built docker image as a local file
         run: |
@@ -193,25 +209,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_GITHUB_TOKEN }}
 
-      - name: Tagging the docker-compose image '${COMPOSE_IMAGE_NAME}' as '${DOCKER_IMAGE_TAG}'
-        run: docker tag ${COMPOSE_IMAGE_NAME} ${DEFAULT_REPO_IMAGE_TAG}
+      - name: Tag & Push the docker-compose image '${{needs.build.outputs.image_name}}' as '${{env.DOCKER_IMAGE_TAG}}'
+        run: docker tag ${{needs.build.outputs.image_name}} ${{env.DOCKER_IMAGE_TAG}}
 
-      - name: Tag with the branch name
-        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_REF##*/}
+      - name: Tag & Push the docker-compose image '${{needs.build.outputs.image_name}}' as 'docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_REF##*/}'
+        run: docker tag ${{needs.build.outputs.image_name}} docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_REF##*/}
 
-      - name: Tag the latest image
-        if: endsWith(github.ref, '/main')
-        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:latest
-
-      # Publish the Branch Docker Images to Github Container Registry
-      - name: Push latest Docker Image
-        run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA}
-
-      # Publish the Sha  Docker Images to Github Container Registry
-      - name: Push Docker Image
-        run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_REF##*/}
-
-       # Publish the Sha  Docker Images to Github Container Registry
-      - name: Push Docker Image latest from master
+      - name: Tag & Push the docker-compose image '${{needs.build.outputs.image_name}}' as 'docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:latest'
         if: endsWith(github.ref, '/main') || endsWith(github.ref, '/master')
-        run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:latest
+        run: docker ${{needs.build.outputs.image_name}} docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:latest

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -1,0 +1,124 @@
+# https://www.freecodecamp.org/news/a-lightweight-tool-agnostic-ci-cd-flow-with-github-actions/
+name: main
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+      - feature/**
+      - bugfix/**
+      - hotfix/**
+    paths-ignore:
+      - '**/README.md' # https://stackoverflow.com/questions/62968897/is-it-possible-to-not-run-github-action-for-readme-updates/62972393#62972393
+  pull_request:
+    branches: [ master, develop, feature/**, bugfix/** ]
+
+# https://faun.pub/building-a-ci-cd-pipeline-with-github-actions-and-docker-part-1-a9d8709c31fb
+jobs:
+
+  build:
+    name: Build CLI Binaries
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: docker/compose:1.29.2
+
+    env:
+      DOCKER_IMAGE_TAG: "docker.pkg.github.com/${GITHUB_REPOSITORY}/${GITHUB_REF##*/}"
+      # https://github.com/actions/starter-workflows/issues/68#issuecomment-524665878
+
+      DOCKER_CONTEXT_PATH: "haskell_101/codelab"
+      IMAGE_NAME_SUFFIX: haskell_101
+
+    steps:
+      - name: Repo Name
+        run: |
+           echo "GITHUB_IMAGE_REPO_NAME=$( echo ${GITHUB_REPOSITORY} | awk -F'/' '{ print $2 }' )-${{env.IMAGE_NAME_SUFFIX}}" >> $GITHUB_ENV
+
+      - name: Public Docker Repo Name
+        run: |
+           echo "PUBLIC_DOCKER_REPO=$( echo ${GITHUB_REPOSITORY} | sed 's/-docker//g' | sed 's/docker-//g' )" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v2
+        with:
+          # https://github.com/actions/checkout/pull/258 needs to fetch all tags so that Makefile can make the correct version
+          fetch-depth: 0
+
+      - name: Build docker image
+        # https://stackoverflow.com/questions/55756372/when-using-buildkit-with-docker-how-do-i-see-the-output-of-run-commands/55759337#55759337
+        run: |
+          echo "Building the context dir ${{env.DOCKER_CONTEXT_PATH}}"
+          cd ${{env.DOCKER_CONTEXT_PATH}}
+
+          COMPOSE_IMAGE_NAME=$(docker-compose config | docker run --rm -i mikefarah/yq e . - -o json | docker run --rm -i imega/jq -r '.services | first(.[]).image')
+          echo "Building image from docker-compose: ${IMAGE_NAME}"
+
+          docker-compose build
+
+          DEFAULT_REPO_IMAGE_TAG=docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA}
+          echo "Tagging the docker-compose image '${COMPOSE_IMAGE_NAME}' as '${DEFAULT_REPO_IMAGE_TAG}'"
+          docker tag ${COMPOSE_IMAGE_NAME} ${DEFAULT_REPO_IMAGE_TAG} 
+
+      - name: Tag with the branch name
+        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_REF##*/}
+
+      - name: Tag the latest image
+        if: endsWith(github.ref, '/main')
+        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:latest
+
+      # https://github.com/marcellodesales/cloner/packages?package_type=Docker
+      - name: Login to GitHub Packages Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.REGISTRY_GITHUB_TOKEN }}
+
+      # Publish the Branch Docker Images to Github Container Registry
+      - name: Push latest Docker Image
+        run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA}
+
+      # Publish the Sha  Docker Images to Github Container Registry
+      - name: Push Docker Image
+        run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_REF##*/}
+
+       # Publish the Sha  Docker Images to Github Container Registry
+      - name: Push Docker Image latest from master
+        if: endsWith(github.ref, '/main')
+        run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:latest
+
+      - name: Docker image to push
+        run: echo "Image repo is '${{env.PUBLIC_DOCKER_REPO}}'"
+
+      # https://github.com/marcellodesales/cloner/packages?package_type=Docker
+      - name: Login to Dockerhub Registry
+        uses: docker/login-action@v1
+        with:
+          #registry: docker.com
+          username: marcellodesales
+          password: ${{ secrets.REGISTRY_DOCKERHUB_TOKEN }}
+
+      - name: Tag the latest image in the public repo
+        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} ${{env.PUBLIC_DOCKER_REPO}}:${GITHUB_SHA}
+
+      - name: Tag the latest image in the public repo
+        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} ${{env.PUBLIC_DOCKER_REPO}}:${GITHUB_REF##*/}
+
+       # Latest version of image
+      - name: Docker Push the latest image
+        if: endsWith(github.ref, '/main') || endsWith(github.ref, '/master')
+        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/${{env.GITHUB_IMAGE_REPO_NAME}}:${GITHUB_SHA} ${{env.PUBLIC_DOCKER_REPO}}
+
+      - name: Tag the latest image in the public repo
+        run: docker push ${{env.PUBLIC_DOCKER_REPO}}:${GITHUB_SHA}
+
+      - name: Tag the latest image in the public repo
+        run: docker push ${{env.PUBLIC_DOCKER_REPO}}:${GITHUB_REF##*/}
+
+       # Latest version of image
+      - name: Docker Push the latest image
+        if: endsWith(github.ref, '/main') || endsWith(github.ref, '/master')
+        run: docker push ${{env.PUBLIC_DOCKER_REPO}}

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -87,12 +87,10 @@ jobs:
         run: |
           ls -lar
           EXERCISES=$(find ${{env.DOCKER_CONTEXT_PATH}} -maxdepth 1 -type d -exec echo {} +;)
-          EXERCISES=$(echo $EXERCISES | tr " " "\n" | tail -n +2 | awk -F"/" '{print $3}')
-          echo "List of exercises: ${EXERCISES}"
-
-          GITHUB_MATRIX_PACKAGES=$(docker run --rm -i imega/jq -nc '{package: $ARGS.positional[0] | split("\n")}' --args ${EXERCISES[@]})
-          echo "Dynamic github matrix packages"
-          echo ${GITHUB_MATRIX_PACKAGES} | docker run --rm -i imega/jq .
+          GITHUB_MATRIX_PACKAGES=$(echo '{ "package" : ['
+            echo $EXERCISES | sed 's/ /, /g' | xargs -n 1 echo | tail -n +2 | awk -F"/" '{print $3}' | sed -r 's/^([^,]*)(,?)$/"\1"\2/'
+          echo "]}")
+          echo "Dynamic github matrix packages: ${GITHUB_MATRIX_PACKAGES}"
 
           echo "Setting the value as the matrix..."
           echo "::set-output name=matrix::${GITHUB_MATRIX_PACKAGES}"

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -75,7 +75,7 @@ jobs:
           COMPOSE_IMAGE_NAME=$(docker-compose config | docker run --rm -i mikefarah/yq e . - -o json | docker run --rm -i imega/jq -r '.services | first(.[]).image')
           echo "COMPOSE_IMAGE_NAME=${COMPOSE_IMAGE_NAME}" >> $GITHUB_ENV
           echo "Building image from docker-compose: ${COMPOSE_IMAGE_NAME}"
-          docker-compose build
+          DOCKER_BUILDKIT=1 docker-compose build
 
       - name: Saving the built docker image as a local file
         run: |

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -39,6 +39,7 @@ jobs:
       defaultDockerImageVersion: ${{steps.set-base-values.outputs.defaultDockerImageVersion}}
       defaultDockerImageBranchTag: ${{steps.set-base-values.outputs.defaultDockerImageBranchTag}}
       defaultDockerImageBranchShaTag: ${{steps.set-base-values.outputs.defaultDockerImageBranchShaTag}}
+      dockerContextPath: ${{steps.set-base-values.outputs.dockerContextPath}}
 
     steps:
       - name: Set default envs from the env above
@@ -62,6 +63,7 @@ jobs:
           BRANCH_SHA_TAG=${BRANCH_TAG}-$(echo ${GITHUB_SHA} | cut -c1-7)
           echo "Branch tag to use: ${BRANCH_TAG} and ${BRANCH_SHA_TAG}"
 
+          echo "::set-output name=dockerContextPath::$DOCKER_CONTEXT_PATH"
           echo "::set-output name=defaultDockerImageRepo::$DEFAULT_DOCKER_IMAGE_REPO"
           echo "::set-output name=defaultDockerImageVersion::$DEFAULT_DOCKER_IMAGE_VERSION"
           echo "::set-output name=defaultDockerImageBranchTag::$BRANCH_TAG"
@@ -74,7 +76,7 @@ jobs:
     container:
       image: docker/compose:1.29.2
 
-   # Declare our output variable https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
+    # Declare our output variable https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       image_name: ${{ steps.set-compose_image_name.outputs.image_name }}
@@ -85,6 +87,8 @@ jobs:
         with:
           fetch-depth: 1
 
+      #### THIS IS ONLY USED FOR PERSONAL REASONS: gitlab supercash's haskell
+      # Used during pull of Dockerfile
       - name: Login to Gitlab Container Registry to pull Haskell image
         uses: docker/login-action@v1
         with:
@@ -93,10 +97,14 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_GITLAB_TOKEN }}
 
-      - name: Show cloned files scructure
-        run: |
-          docker container run --rm -v $(pwd):$(pwd) iankoulski/tree $(pwd)
-          ls -lar
+      # This is for pushing the built image
+      # https://github.com/marcellodesales/cloner/packages?package_type=Docker
+      - name: Login to GitHub Packages Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.REGISTRY_GITHUB_TOKEN }}
 
       - id: set-matrix
         # The below outputs a JSON array of check tasks for each subproject
@@ -128,7 +136,6 @@ jobs:
       - name: Associate Dockerfile to the repo
         run: |
           env
-          echo "IS THIS ${GITHUB_REPOSITORY}"
           echo "In order to associate the docker image to the repo, we need to associate the Dockerfile to the repo"
           export LABEL_VALUE=https://github.com/${GITHUB_REPOSITORY}
           echo "Adding 'LABEL org.opencontainers.image.source ${LABEL_VALUE}' to Dockerfile"
@@ -138,90 +145,68 @@ jobs:
           # https://stackoverflow.com/questions/845863/how-to-use-in-an-xargs-command/70230514#70230514
           find . -name 'Dockerfile' -print0 | xargs -0 grep -iL "org.opencontainers.image.source" | xargs -0 -I{} sh -c 'echo "LABEL org.opencontainers.image.source ${LABEL_VALUE}" >> {}' -- {}
 
-      - name: Build docker image
+      # https://github.community/t/use-docker-layer-caching-with-docker-compose-build-not-just-docker/156049/3
+      # https://github.com/docker/build-push-action/blob/master/docs/advanced/export-docker.md
+      # https://mmeendez8.github.io/2021/07/19/new-docker-cache-is-out.html 
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
         # https://stackoverflow.com/questions/55756372/when-using-buildkit-with-docker-how-do-i-see-the-output-of-run-commands/55759337#55759337
-        run: |
-          echo "Building the context dir ${{env.DOCKER_CONTEXT_PATH}}"
-          cd ${{env.DOCKER_CONTEXT_PATH}}
-
-          COMPOSE_IMAGE_NAME=$(docker-compose config | docker run --rm -i mikefarah/yq e . - -o json | docker run --rm -i imega/jq -r '.services | first(.[]).image')
-          echo "COMPOSE_IMAGE_NAME=${COMPOSE_IMAGE_NAME}" >> $GITHUB_ENV
-          echo "Building image from docker-compose: ${COMPOSE_IMAGE_NAME}"
-          DOCKER_BUILDKIT=1 docker-compose build
-
-      - id: set-compose_image_name
-        # The below outputs a JSON array of check tasks for each subproject
-        #  and uses GitHub Actions magic (::set-output) to set an output
-        #  variable https://www.cynkra.com/blog/2020-12-23-dynamic-gha/
-        run: |
-          # Build a matrix of values to generate parallel stages, one for each exercise
-          # https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
-          # https://rnorth.org/faster-parallel-github-builds/
-          # https://www.cynkra.com/blog/2020-12-23-dynamic-gha/
-          # https://github.com/r-dbi/DBItest/blob/main/.github/workflows/backends.yaml
-          echo "Setting the value of the container image name: ${COMPOSE_IMAGE_NAME}"
-
-          # MAKE SURE TO NOT USE ${} in variables for set-output
-          echo "::set-output name=image_name::$COMPOSE_IMAGE_NAME"
-
-      - name: Saving the built docker image as a local file
-        run: |
-          echo "Saving the image locally at dir ${{env.LOCAL_IMAGE_BIN_PATH}}"
-          mkdir ${{env.LOCAL_IMAGE_BIN_PATH}}
-          docker save -o ${{env.LOCAL_IMAGE_BIN_PATH}}/${{env.LOCAL_IMAGE_BIN_NAME}} ${COMPOSE_IMAGE_NAME}
-
-          ls -la ${{env.LOCAL_IMAGE_BIN_PATH}}/${{env.LOCAL_IMAGE_BIN_NAME}}
-          ls -lah ${{env.LOCAL_IMAGE_BIN_PATH}}/${{env.LOCAL_IMAGE_BIN_NAME}}
-
-      - name: Upload Docker Image to pipelie artifacts
-        uses: actions/upload-artifact@v2
+      - name: Build Docker Image with Cache
+        uses: docker/build-push-action@v2
         with:
-          name: training-image
-          path: ${{env.LOCAL_IMAGE_BIN_PATH}}/${{env.LOCAL_IMAGE_BIN_NAME}}
+          push: true
+          # https://github.community/t/use-docker-layer-caching-with-docker-compose-build-not-just-docker/156049/3
+          #load: true Error: buildx failed with: error: push and load may not be set together at the moment
+          tags: ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}}
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ${{needs.setup.outputs.dockerContextPath}}/Dockerfile
+          context: ${{needs.setup.outputs.dockerContextPath}}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          #cache-from: type=local,src=/tmp/.buildx-cache
+          #cache-to: type=local,dest=/tmp/.buildx-cache
 
-  test:
-    needs: build
-    name: Executing the Solutions
+      # Just show the metadata built in case one needs to review/reuse the data
+      - name: Docker Image digest outputs
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  # Executes each exercise in parallel in isolated docker containers using Github's Build Matrix
+  verify:
+    needs: [setup, build]
+    name: Verify
     runs-on: ubuntu-latest
-    container:
-      image: docker/compose:1.29.2
 
-    # Composite github : https://stackoverflow.com/questions/65242830/in-a-github-actions-workflow-is-there-a-way-to-have-multiple-jobs-reuse-the-sam/65243912#65243912
+    # TODO: Composite github : https://stackoverflow.com/questions/65242830/in-a-github-actions-workflow-is-there-a-way-to-have-multiple-jobs-reuse-the-sam/65243912#65243912
     # Just use a matrix to run the tests for each individual exercise
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.build.outputs.matrix)}}
 
     steps:
-      - name: Download built training-image
-        uses: actions/download-artifact@v2
-        with:
-          name: training-image
-
-      - name: Load Docker Image Binary for cache
-        run: |
-          ls -la ${{env.LOCAL_IMAGE_BIN_NAME}}
-          docker load -i ${{env.LOCAL_IMAGE_BIN_NAME}}
-
-      - name: List the docker images locally
-        run: |
-          docker images
-
-      - name: Fetch only the top commit
+      - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
 
-      - name: Show cloned files structure
-        run: |
-          docker container run --rm -v $(pwd):$(pwd) iankoulski/tree $(pwd)
-          ls -lar
+      # https://github.com/marcellodesales/cloner/packages?package_type=Docker
+      - name: Login to GitHub Packages Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.REGISTRY_GITHUB_TOKEN }}
 
       - name: Run ${{matrix.package}} tests
         # https://stackoverflow.com/questions/55756372/when-using-buildkit-with-docker-how-do-i-see-the-output-of-run-commands/55759337#55759337
         run: |
+          # Since docker-compose uses the image defined with a different name, let's just tag the CICD image loaded before
           echo "Building the context dir ${{env.DOCKER_CONTEXT_PATH}}"
           cd ${{env.DOCKER_CONTEXT_PATH}}
+
+          COMPOSE_IMAGE=$(docker-compose config | grep image: | awk '{ print $2 }' | tail -1)
+          echo "Will tag docker-compose image '${COMPOSE_IMAGE}' as the CICD image '${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}}'"
+          docker pull ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}}
+          docker tag ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}} ${COMPOSE_IMAGE}
 
           echo "Since the image is already built and loaded: docker-compose: ${COMPOSE_IMAGE_NAME} ${{matrix.package}}"
           docker-compose run ${{matrix.package}}
@@ -243,20 +228,6 @@ jobs:
           echo "Output key: needs.setup.outputs.defaultDockerImageVersion=${{needs.setup.outputs.defaultDockerImageVersion}}"
           echo "Output key: needs.setup.outputs.defaultDockerImageBranchTag=${{needs.setup.outputs.defaultDockerImageBranchTag}}"
 
-      - name: Download built training-image
-        uses: actions/download-artifact@v2
-        with:
-          name: training-image
-
-      - name: Load Docker Image Binary for cache
-        run: |
-          ls -la ${{env.LOCAL_IMAGE_BIN_NAME}}
-          docker load -i ${{env.LOCAL_IMAGE_BIN_NAME}}
-
-      - name: List the docker images locally
-        run: |
-          docker images
-
       # https://github.com/marcellodesales/cloner/packages?package_type=Docker
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1
@@ -265,24 +236,23 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_GITHUB_TOKEN }}
 
-      # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions
-      - name: Tag & Push SHA docker-compose image '${{needs.build.outputs.image_name}}' as '${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}}'
+      - name: Pull the built docker images locally
         run: |
-          docker tag ${{needs.build.outputs.image_name}} ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}}
-          docker push ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}}
+          docker pull ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}}
+          docker images
 
-      - name: Tag & Push BRANCH docker-compose image '${{needs.build.outputs.image_name}}' as '${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchTag}}'
+      - name: Push BRANCH docker-compose image '${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}}' as '${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchTag}}'
         run: |
-          docker tag ${{needs.build.outputs.image_name}} ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchTag}}
+          docker tag ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}} ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchTag}}
           docker push ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchTag}}
 
-      - name: Tag & Push BRANCH-SHA docker-compose image '${{needs.build.outputs.image_name}}' as '${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchShaTag}}'
+      - name: Push BRANCH-SHA docker-compose image '${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}}' as '${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchShaTag}}'
         run: |
-          docker tag ${{needs.build.outputs.image_name}} ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchShaTag}}
-          docker push ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchShaTag}}
+          docker tag ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}} ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchShaTag}}
+          docker push ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageBranchShaTag}} 
 
       - if: endsWith(github.ref, '/main') || endsWith(github.ref, '/master')
-        name: Tag & Push LATEST docker-compose image '${{needs.build.outputs.image_name}}' as '${{needs.setup.outputs.defaultDockerImageRepo}}:latest'
+        name: Push LATEST docker-compose image '${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}}' as '${{needs.setup.outputs.defaultDockerImageRepo}}:latest'
         run: |
-          docker tag ${{needs.build.outputs.image_name}} ${{steps.setup.outputs.defaultDockerImageRepo}}:latest
-          docker push ${{steps.setup.outputs.defaultDockerImageRepo}}:latest
+          docker tag ${{needs.setup.outputs.defaultDockerImageRepo}}:${{needs.setup.outputs.defaultDockerImageVersion}} ${{needs.setup.outputs.defaultDockerImageRepo}}:latest
+          docker push ${{needs.setup.outputs.defaultDockerImageRepo}}:latest

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -51,7 +51,7 @@ jobs:
            echo "PUBLIC_DOCKER_REPO=$(echo ${GITHUB_REPOSITORY} | sed 's/-docker//g' | sed 's/docker-//g' )" >> $GITHUB_ENV
 
   build:
-    name: Build CLI Binaries
+    name: Build Docker Image with Haskell Training-101
     needs: setup
     runs-on: ubuntu-latest
     container:
@@ -102,7 +102,7 @@ jobs:
 
   test:
     needs: build
-    name: Testing
+    name: Executing the Solutions
     runs-on: ubuntu-latest
     container:
       image: docker/compose:1.29.2

--- a/.github/workflows/haskell_101.yaml
+++ b/.github/workflows/haskell_101.yaml
@@ -136,9 +136,9 @@ jobs:
           echo "Since the image is already built and loaded, we can just run... docker-compose: ${COMPOSE_IMAGE_NAME}"
           docker-compose up
 
-  push:
+  deploy:
     name: Tag and Push the docker images
-    needs: build
+    needs: test
     runs-on: ubuntu-latest
     container:
       image: docker/compose:1.29.2

--- a/haskell_101/codelab/Dockerfile
+++ b/haskell_101/codelab/Dockerfile
@@ -19,7 +19,9 @@ FROM registry.gitlab.com/supercash/core/haskell-stack-base:stack-2.7.3_haskell-8
 RUN apk update && \
     apk add vim
 
-WORKDIR /google/trainings/haskell-101
+# Define the working dir as env var so we can use in CICD
+ENV HASKELL_TRAINING_WORKDIR /google/trainings/haskell-101
+WORKDIR ${HASKELL_TRAINING_WORKDIR}
 
 # Copy all cabal dependencies files only, fetched from docker-context
 COPY --from=dependencies /google/trainings/haskell/cabal .

--- a/haskell_101/codelab/docker-compose.yml
+++ b/haskell_101/codelab/docker-compose.yml
@@ -68,8 +68,8 @@ services:
     #<<: [ *docker-cli-mode ]
     command: make -C 05_maybe
 
-  06_rps:
-    <<: [ *generic-haskell-runtime ]
+  #06_rps:
+  #  <<: [ *generic-haskell-runtime ]
     # You can run in CLI mode with "docker-compose run 06_rps". Un-comment the following line and comment the "command" instruction below
     #<<: [ *docker-cli-mode ]
-    command: make -C 06_rps
+  #  command: make -C 06_rps


### PR DESCRIPTION
# 🤔 What if we could build on Github Actions?

* Just building a pipeline to verify the training...
* It should use the same docker resources added
* It provides another level of trust to the student 

# ⚡ Performant Dockerized Github Action 

* Using Docker Buildx Cache mechanism for builds
  * Docker Image Caches of previous pipeline runs are loaded automatically
* Execution of the images using the same `docker-compose` setup 
  * Constantly verifying what the student executes locally in his/her machine
* Subsequent executions can be `~65%` faster that initial builds (time to build the docker image)

## Build with Docker Buildkit: Warm up Cache: 1m 22s

* Fresh builds will take more than a minute without the cache in Github Actions
* Invalidation of cache from any changes to the Dockerfile of tests
  * Different cache invalidations will result in longer builds

<img width="887" alt="Screen Shot 2022-01-15 at 10 17 37 AM" src="https://user-images.githubusercontent.com/131457/149634268-46edb4ad-486a-4c39-b50a-0f82b2cc366e.png">

## Build with Docker Buildkit: With Cache: 27s 

* No changes to the Dockerfile that affects the local cache
  * Upgrading GHCI or Stack or anything will invalidate the cache :) 

> https://github.com/marcellodesales/haskell-trainings/actions/runs/1702251910


<img width="872" alt="Screen Shot 2022-01-15 at 10 30 30 AM" src="https://user-images.githubusercontent.com/131457/149633781-57b3ce44-7ebe-46fd-99d2-479a020980a5.png">


# References

* https://event-driven.io/en/how_to_buid_and_push_docker_image_with_github_actions/
* https://stackoverflow.com/questions/63148639/create-dependencies-between-jobs-in-github-actions/63148947#63148947
* https://github.community/t/sharing-a-variable-between-jobs/16967/14
